### PR TITLE
FIX #7 : BoxError and ClassError can match with used detections

### DIFF
--- a/tidecv/quantify.py
+++ b/tidecv/quantify.py
@@ -233,15 +233,15 @@ class TIDERun:
 					continue
 
 				# Test for BoxError
-				idx = ex.gt_cls_iou[pred_idx, :].argmax()
-				if self.bg_thresh <= ex.gt_cls_iou[pred_idx, idx] <= self.pos_thresh:
+				idx = ex.gt_unused_cls[pred_idx, :].argmax()
+				if self.bg_thresh <= ex.gt_unused_cls[pred_idx, idx] <= self.pos_thresh:
 					# This detection would have been positive if it had higher IoU with this GT
 					self._add_error(BoxError(pred, ex.gt[idx], ex))
 					continue
 
 				# Test for ClassError
-				idx = ex.gt_noncls_iou[pred_idx, :].argmax()
-				if ex.gt_noncls_iou[pred_idx, idx] >= self.pos_thresh:
+				idx = ex.gt_unused_noncls[pred_idx, :].argmax()
+				if ex.gt_unused_noncls[pred_idx, idx] >= self.pos_thresh:
 					# This detection would have been a positive if it was the correct class
 					self._add_error(ClassError(pred, ex.gt[idx], ex))
 					continue
@@ -255,8 +255,8 @@ class TIDERun:
 					continue
 					
 				# Test for BackgroundError
-				idx = ex.gt_iou[pred_idx, :].argmax()
-				if ex.gt_iou[pred_idx, idx] <= self.bg_thresh:
+				idx = ex.gt_unused_iou[pred_idx, :].argmax()
+				if ex.gt_unused_iou[pred_idx, idx] <= self.bg_thresh:
 					# This should have been marked as background
 					self._add_error(BackgroundError(pred))
 					continue


### PR DESCRIPTION
Hey,

I gave a quick shot at fixing the error discussed in #7.
Basically, it involves changing the IoU matrix in 3 different places: BoxError, ClassError, BackgroundError.

__BoxError__:  
Here we use `gt_unused_cls` instead of `gt_cls_iou`, because we only want to match for localisation errors with unmatched annotations.

__ClassError__:
Here we use `gt_unused_noncls` instead of `gt_noncls_iou`, because we only want to match for classification errors with unmatched annotations.

__BackgroundError__:
Here we use `gt_unused_iou` instead of `gt_iou`, because we want to have BackgroundErrors when there is no suiteable unmatched annotation. If we would leave this to `gt_iou`, it would cause detections that failed the BoxError/ClassError because we know only match with unused annotations to become OtherErrors, while they should in fact be BackgroundErrors (IMO).