### PR TITLE
Add Per Class Analysis and Class Confusion Matrix

### DIFF
--- a/tidecv/ap.py
+++ b/tidecv/ap.py
@@ -149,6 +149,9 @@ class ClassedAPDataObject:
 		aps = [x.get_ap() for x in self.objs.values() if not x.is_empty()]
 		return sum(aps) / len(aps)
 
+        def get_per_class_APs(self) -> dict:                                          
+                return {k : v.get_ap() for k, v in self.objs.items()}  
+
 	def get_gt_positives(self) -> dict:
 		return {k: v.num_gt_positives for k, v in self.objs.items()}
 

--- a/tidecv/functions.py
+++ b/tidecv/functions.py
@@ -87,8 +87,11 @@ def toRLE(mask:object, w:int, h:int):
 	if type(mask) == list:
 		# polygon -- a single object might consist of multiple parts
 		# we merge all parts into one mask rle code
-		rles = maskUtils.frPyObjects(mask, h, w)
-		return maskUtils.merge(rles)
+		if mask:
+			rles = maskUtils.frPyObjects(mask, h, w)
+			return maskUtils.merge(rles)
+		else:
+			return mask
 	elif type(mask['counts']) == list:
 		# uncompressed RLE
 		return maskUtils.frPyObjects(mask, h, w)


### PR DESCRIPTION
1. Add per class dAP analysis.
2. Add Confusion matrix according to class errors
3. fix crash when there are only detection results in labels and segmentation section is empty list "[]".